### PR TITLE
Fix P2P connection failure due to API mismatch

### DIFF
--- a/p2p.js
+++ b/p2p.js
@@ -29,7 +29,7 @@ export async function createNode(peerId) {
       tcp(),
       webSockets()
     ],
-    connectionEncryption: [noise()],
+    connectionEncrypters: [noise()],
     streamMuxers: [yamux()],
     services: {
       identify: identify(),

--- a/test_connection.js
+++ b/test_connection.js
@@ -39,7 +39,7 @@ async function testConnection() {
       tcp(),
       webSockets()
     ],
-    connectionEncryption: [noise()],
+    connectionEncrypters: [noise()],
     streamMuxers: [yamux()],
     services: {
       identify: identify()


### PR DESCRIPTION
The P2P connection was failing with an `EncryptionFailedError`. This was caused by an incorrect property name (`connectionEncryption` instead of `connectionEncrypters`) being used for the security protocol configuration. This was likely due to a silent breaking change in a `libp2p` dependency upgrade.

This commit corrects the property name to `connectionEncrypters` in both `p2p.js` and `test_connection.js`, aligning the API usage across the nodes and restoring the P2P connection functionality.